### PR TITLE
Fix ilike

### DIFF
--- a/api/src/lib/generateLikeFilters.ts
+++ b/api/src/lib/generateLikeFilters.ts
@@ -1,4 +1,4 @@
-import { SQL, ilike, or } from "drizzle-orm";
+import { SQL, like, or } from "drizzle-orm";
 import { SQLiteColumn } from "drizzle-orm/sqlite-core";
 
 export const generateLikeFilters = (filters: { col: SQLiteColumn; val?: string | null }[]) => {
@@ -6,7 +6,7 @@ export const generateLikeFilters = (filters: { col: SQLiteColumn; val?: string |
 
   for (const { col, val } of filters) {
     if (val) {
-      where.push(ilike(col, `${val}%`));
+      where.push(like(col, `${val}%`));
     }
   }
 


### PR DESCRIPTION
Fix error reported by @rishi-shah12 
```
LibsqlError: SQL_PARSE_ERROR: SQL string could not be parsed: syntax error around L1:189: `ilike`
    at mapHranaError (file:///Users/rishishah/Desktop/4B/ECE_452/SE2-App/api/node_modules/@libsql/client/lib-esm/hrana.js:257:16)
    at HttpClient.execute (file:///Users/rishishah/Desktop/4B/ECE_452/SE2-App/api/node_modules/@libsql/client/lib-esm/http.js:53:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async LibSQLPreparedQuery.all (file:///Users/rishishah/Desktop/4B/ECE_452/SE2-App/api/node_modules/drizzle-orm/libsql/session.js:106:18)
    at async Object.<anonymous> (file:///Users/rishishah/Desktop/4B/ECE_452/SE2-App/api/src/routes/users.ts:1:3086) {
  code: 'SQL_PARSE_ERROR',
  rawCode: undefined,
  [cause]: [ResponseError: SQL string could not be parsed: syntax error around L1:189: `ilike`] {
    code: 'SQL_PARSE_ERROR',
    proto: {
      message: 'SQL string could not be parsed: syntax error around L1:189: `ilike`',
      code: 'SQL_PARSE_ERROR'
    }
  }
}
```