### PR TITLE
Remaining Friends Actions

### DIFF
--- a/mobile/app/src/main/java/ca/uwaterloo/tunein/ProfileActivity.kt
+++ b/mobile/app/src/main/java/ca/uwaterloo/tunein/ProfileActivity.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip

--- a/mobile/app/src/main/java/ca/uwaterloo/tunein/auth/AuthManager.kt
+++ b/mobile/app/src/main/java/ca/uwaterloo/tunein/auth/AuthManager.kt
@@ -1,9 +1,7 @@
 package ca.uwaterloo.tunein.auth
 
 import android.content.Context
-import android.util.Log
 import ca.uwaterloo.tunein.data.User
-import ca.uwaterloo.tunein.messaging.Firebase
 
 private const val PREF_NAME = "auth_pref"
 private val KEY_AUTH_TOKEN = "auth_token"

--- a/mobile/app/src/main/java/ca/uwaterloo/tunein/viewmodel/FriendsViewModel.kt
+++ b/mobile/app/src/main/java/ca/uwaterloo/tunein/viewmodel/FriendsViewModel.kt
@@ -74,6 +74,7 @@ suspend fun getFriends(context: Context): List<User> = withContext(Dispatchers.I
         .addHeader("Authorization", "Bearer ${AuthManager.getAuthToken(context).toString()}")
         .build()
 
+
     val response = client.newCall(request).execute()
     val json = response.body.string()
     val j = Json { ignoreUnknownKeys = true }

--- a/mobile/app/src/main/java/ca/uwaterloo/tunein/viewmodel/SearchResultsViewModel.kt
+++ b/mobile/app/src/main/java/ca/uwaterloo/tunein/viewmodel/SearchResultsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -18,19 +19,45 @@ import okhttp3.OkHttpClient
 
 data class SearchUsers(
     val searchQuery: TextFieldValue = TextFieldValue(),
-    val users: List<User> = emptyList()
+    val users: List<SearchResults> = emptyList(),
+    val friends: List<SearchResults> = emptyList(),
+    val friendRequests: List<SearchResults> = emptyList(),
 )
 
-suspend fun fetchSearchUsers(searchQuery: String): List<User> = withContext(Dispatchers.IO) {
-    val searchUrl = "${BuildConfig.BASE_URL}/users?search=${searchQuery}"
+@Serializable
+data class SearchResults(
+    val id: String = "",
+    val username: String = "",
+    val firstName: String = "",
+    val lastName: String = "",
+    val friendshipRequest: String?,
+    val friendship: String?,
+)
+
+fun searchResultsToUser(user: SearchResults): User {
+    return User (
+        id = user.id,
+        username = user.username,
+        firstName = user.firstName,
+        lastName = user.lastName
+    )
+}
+
+suspend fun fetchSearchUsers(user: User, searchQuery: String): List<SearchResults> = withContext(Dispatchers.IO) {
+    val searchUrl = "${BuildConfig.BASE_URL}/friendships/search"
+    val url = searchUrl.toHttpUrl()
+        .newBuilder()
+        .addQueryParameter("search", searchQuery)
+        .addQueryParameter("id", user.id)
+
     val request = okhttp3.Request(
-        url = searchUrl.toHttpUrl()
+        url = url.build()
     )
     val response = OkHttpClient().newCall(request).execute()
 
     val json = response.body.string()
     val j = Json{ ignoreUnknownKeys = true }
-    j.decodeFromString<List<User>>(json)
+    j.decodeFromString<List<SearchResults>>(json)
 }
 
 class SearchResultsViewModel : ViewModel() {
@@ -39,9 +66,14 @@ class SearchResultsViewModel : ViewModel() {
 
     fun updateSearchUsers(user: User, searchQuery: TextFieldValue) {
         viewModelScope.launch {
-            val users = fetchSearchUsers(searchQuery.text).filter { u -> u.id != user.id }
+            val users = fetchSearchUsers(user, searchQuery.text).filter { u -> u.id != user.id }
+            val friends = users.filter { u -> !u.friendship.isNullOrEmpty() }
+            val activeFriendRequests = users.filter { u -> !u.friendshipRequest.isNullOrEmpty() }
+            val rest = users.filter { u -> u.friendship.isNullOrEmpty() && u.friendshipRequest.isNullOrEmpty() }
             _searchUsers.value = _searchUsers.value.copy(
-                users = users,
+                users = rest,
+                friendRequests = activeFriendRequests,
+                friends = friends,
                 searchQuery = searchQuery
             )
         }

--- a/timelog.md
+++ b/timelog.md
@@ -21,4 +21,5 @@
 | 2024/03/04 |       |       |         | 2       |        |        | Routing and bug fixing for profile and settings                    |
 | 2024/03/05 |       |       |         | 3       |        |        | Pop-up menus for confirmation and entry in profile and settings    |
 | 2024/03/06 |       |       |         | 4       |        |        | Get most recent song API work and D3 Status Report section         |
-| 2024/03/17 |       |       |         |         |        | 6      | Finish add fiends workflow with correct authorization header       |
+| 2024/03/16 |       |       |         |         |        | 5      | Finish add fiends workflow with correct authorization header       |
+| 2024/03/17 |       |       |         |         |        | 6      | Finish actions for searching / removing / adding friends           |


### PR DESCRIPTION
- Implementing remaining friends actions
- Faced certain challenges & handling edge cases (such as two users sending each other friend requests at the same time)
- Needed to ensure UI and database remained consistent and correctly separated users by if they are friends / not friends / pending friends
- Nice-to-have feature would be when searching for users, separating "outgoing friend requests" from "incoming friends requests", but that's a nice-to-have